### PR TITLE
Refactor v24

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,5 @@ drivers
 tsconfig.json
 .idea
 types.d.ts
-/frontend/generated/index.ts
-/frontend/generated/vaadin.ts
+/frontend/generated
 /frontend/index.html

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
             <dependency>
             	<groupId>com.flowingcode.vaadin.addons.demo</groupId>
             	<artifactId>commons-demo</artifactId>
-            	<version>3.5.0</version>
+            	<version>3.5.1</version>
             </dependency>
 		</dependencies>
 	</dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -481,6 +481,16 @@
 				</plugins>
 			</build>
 		</profile>
+		<profile>
+			<id>v24</id>
+			<properties>
+				<vaadin.version>24.0.0.alpha5</vaadin.version>
+				<maven.compiler.source>17</maven.compiler.source>
+				<maven.compiler.target>17</maven.compiler.target>
+				<jetty.version>11.0.12</jetty.version>
+				<flowingcode.commons.demo.version>3.5.1</flowingcode.commons.demo.version>
+			</properties>
+		</profile>
 	</profiles>
 
 </project>

--- a/src/main/java/com/flowingcode/addons/ycalendar/MonthCalendar.java
+++ b/src/main/java/com/flowingcode/addons/ycalendar/MonthCalendar.java
@@ -24,6 +24,7 @@ import com.vaadin.flow.component.HasTheme;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.datepicker.DatePicker;
 import com.vaadin.flow.component.dependency.JsModule;
+import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.component.dependency.Uses;
 import com.vaadin.flow.function.ValueProvider;
 import java.time.LocalDate;
@@ -35,6 +36,7 @@ import java.util.stream.IntStream;
 @Tag("fc-month-calendar")
 @JsModule("./fc-month-calendar/month-calendar-mixin.js")
 @JsModule("./fc-month-calendar/fc-month-calendar.js")
+@NpmPackage(value = "@polymer/iron-a11y-keys-behavior", version = "3.0.1")
 @Uses(DatePicker.class)
 @SuppressWarnings("serial")
 public class MonthCalendar extends AbstractCalendarComponent<MonthCalendar> implements HasSize, HasTheme {

--- a/src/main/resources/META-INF/frontend/fc-year-calendar/fc-year-calendar.js
+++ b/src/main/resources/META-INF/frontend/fc-year-calendar/fc-year-calendar.js
@@ -20,7 +20,7 @@
 import {html, PolymerElement} from '@polymer/polymer/polymer-element.js';
 import {ThemableMixin} from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';
 import {} from '@polymer/polymer/lib/elements/dom-repeat.js';
-import {} from '@vaadin/vaadin-form-layout/src/vaadin-form-layout.js';
+import {} from '@vaadin/form-layout/src/vaadin-form-layout.js';
 import {} from '../fc-month-calendar/fc-month-calendar.js';
 
 import {formatDate} from '../fc-year-calendar/fc-calendar-utils.js';


### PR DESCRIPTION
- replace import from `@vaadin/vaadin-form-layout`: it was removed in Vaadin 24, and it's just an alias of `@vaadin/form-layout` in Vaadin 22-23.

- add npm import of `@polymer/iron-a11y-keys-behavior` (it's no longer implicit in Vaadin 24)