### PR TITLE
Set version to 2.3.0 and remove v24 profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -494,16 +494,6 @@
 			</properties>
 		</profile>
 
-		<profile>
-			<id>v24</id>
-			<properties>
-				<vaadin.version>24.0.0.beta1</vaadin.version>
-				<maven.compiler.source>17</maven.compiler.source>
-				<maven.compiler.target>17</maven.compiler.target>
-				<jetty.version>11.0.12</jetty.version>
-				<flowingcode.commons.demo.version>3.5.1</flowingcode.commons.demo.version>
-			</properties>
-		</profile>
 	</profiles>
 
 </project>


### PR DESCRIPTION
- Increment minor version because #44 introduces a new feature in this branch
- Remove `v24` profile since version 2.x is compatible with Vaadin 22-23 (see #48)