### PR TITLE
fix: cleanup CSS styles on empty cells in MonthCalendar

### DIFF
--- a/src/main/java/com/flowingcode/addons/ycalendar/MonthCalendar.java
+++ b/src/main/java/com/flowingcode/addons/ycalendar/MonthCalendar.java
@@ -102,6 +102,7 @@ public class MonthCalendar extends AbstractCalendarComponent<MonthCalendar> impl
       }
       setStyleForDay(dayOfMonth, className);
     });
+    getElement().executeJs("setTimeout(()=>this._clearEmptyDaysStyle())");
   }
 
   /**


### PR DESCRIPTION
- Close #58