### PR TITLE
Fix javadoc

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -307,7 +307,7 @@
                         <configuration>
                             <quiet>true</quiet>
                             <doclint>none</doclint>
-                            <failOnWarnings>false</failOnWarnings>
+                            <failOnWarnings>true</failOnWarnings>
                             <links>
                                 <link>https://javadoc.io/doc/com.vaadin/vaadin-platform-javadoc/${vaadin.version}</link>
                             </links>

--- a/src/main/java/com/flowingcode/addons/ycalendar/YearMonthField.java
+++ b/src/main/java/com/flowingcode/addons/ycalendar/YearMonthField.java
@@ -89,7 +89,7 @@ public class YearMonthField extends AbstractSinglePropertyField<YearMonthField, 
   /**
    * Sets the maximum year/month in the field.
    *
-   * @param min the maximum year/month that is allowed to be selected, or <code>null</code> to
+   * @param max the maximum year/month that is allowed to be selected, or <code>null</code> to
    *        remove any maximum constraints
    */
   public void setMax(YearMonth max) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved documentation clarity for the `setMax` method in the `YearMonthField` class, ensuring users understand the maximum selection parameter.

- **Bug Fixes**
	- Updated Javadoc parameter name from `min` to `max` in the `setMax` method to accurately reflect its purpose.

- **Chores**
	- Enhanced error handling during Javadoc generation by enforcing stricter compliance with documentation standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->