### PR TITLE
Fix demo styles for Vaadin 24.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ types.d.ts
 /vite.generated.ts
 /.npmrc
 src/main/dev-bundle
+/src/main/frontend

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 	<description>Year Month Calendar Add-on for Vaadin Flow</description>
 
 	<properties>
-		<vaadin.version>24.4.4</vaadin.version>
+		<vaadin.version>24.5.0</vaadin.version>
 		<maven.compiler.source>17</maven.compiler.source>
 		<maven.compiler.target>17</maven.compiler.target>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -150,7 +150,7 @@
 		<dependency>
 			<groupId>io.github.bonigarcia</groupId>
 			<artifactId>webdrivermanager</artifactId>
-			<version>3.8.1</version>
+			<version>5.9.2</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -237,14 +237,8 @@
 				<artifactId>jetty-maven-plugin</artifactId>
 				<version>${jetty.version}</version>
 				<configuration>
-					<scanIntervalSeconds>3</scanIntervalSeconds>
 					<!-- Use test scope because the UI/demo classes are in the test package. -->
 					<useTestScope>true</useTestScope>
-					<webAppConfig>
-						<resourceBases>
-							<resourceBase>src/test/resources/META-INF/resources</resourceBase>
-						</resourceBases>
-					</webAppConfig>
 					<supportedPackagings>
 						<supportedPackaging>jar</supportedPackaging>
 					</supportedPackagings>

--- a/pom.xml
+++ b/pom.xml
@@ -242,6 +242,9 @@
 					<supportedPackagings>
 						<supportedPackaging>jar</supportedPackaging>
 					</supportedPackagings>
+					<systemProperties>
+						<vaadin.frontend.hotdeploy>true</vaadin.frontend.hotdeploy>
+					</systemProperties>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/src/test/resources/META-INF/frontend/styles/test_year-month-calendar.css
+++ b/src/test/resources/META-INF/frontend/styles/test_year-month-calendar.css
@@ -17,14 +17,14 @@
  * limitations under the License.
  * #L%
  */
-[part='date'].holiday {
+[part~='date'].holiday {
   color: var(--lumo-error-contrast-color);
 }
 
-[part='date'].holiday::before {
+[part~='date'].holiday::before {
   background-color: var(--lumo-error-color);
 }
 
-[part='date'].weekend {
+[part~='date'].weekend {
   color: var(--lumo-error-color);
 }


### PR DESCRIPTION
It must be `[part~='date']` instead of `[part='date']`. I also updated the configuration for Vaadin 24.5.
Whatever the rabbit says after me is a lie.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated `.gitignore` to include the `src/main/frontend` directory.
- **New Features**
	- Updated `vaadin.version` from `24.4.4` to `24.5.0`.
	- Updated `webdrivermanager` dependency from `3.8.1` to `5.9.2`.
	- Added a new `demo-jar` profile for creating a test jar.
- **Style**
	- Modified CSS selectors in `test_year-month-calendar.css` for improved styling of `holiday` and `weekend` classes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->