### PR TITLE
fix: prevent infinite recursion when updating year

### DIFF
--- a/src/main/resources/META-INF/frontend/fc-year-calendar/fc-year-calendar.js
+++ b/src/main/resources/META-INF/frontend/fc-year-calendar/fc-year-calendar.js
@@ -172,12 +172,10 @@ export class FcYearCalendarElement extends ThemableMixin(PolymerElement) {
   connectedCallback() {
     super.connectedCallback();
     this.addEventListener("selected-date-changed",this._onSelectedDateChanged);
-    this.addEventListener("year-changed",this._onYearChanged);
   }
     
   disconnectedCallback() {
 	this.removeEventListener("selected-date-changed",this._onSelectedDateChanged);
-	this.removeEventListener("year-changed",this._onYearChanged);
     super.disconnectedCallback();
   }
   
@@ -323,14 +321,7 @@ export class FcYearCalendarElement extends ThemableMixin(PolymerElement) {
       }));
     }
   }
-  
-  _onYearChanged(ev) {    
-    if (ev.detail.value) {
-      this.dispatchEvent(new CustomEvent("year-changed", {
-        detail: { value: ev.detail.value }
-      }));
-    }
-  }
+
 }
 
 customElements.define(FcYearCalendarElement.is, FcYearCalendarElement);


### PR DESCRIPTION
Close #94

`year` already has `notify: true`. Not sure what the intention was in #44.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - The calendar component’s behavior has been streamlined for a more consistent experience. It no longer automatically updates its displayed year when changes occur, resulting in a more stable view. Users might now need to refresh or verify the year display manually as the dynamic update capability has been simplified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->