### PR TITLE
fix: disable internal button focus in ExtendedDatePicker

### DIFF
--- a/src/main/resources/META-INF/frontend/fc-date-picker/fc-date-picker-buttons.js
+++ b/src/main/resources/META-INF/frontend/fc-date-picker/fc-date-picker-buttons.js
@@ -29,12 +29,12 @@ export class FcDatePickerButtons extends ThemableMixin(LitElement) {
     return html`
        <div id="up">
           <button type="button"
-                  aria-label="Increment"
+                  tabindex="-1"
                   @click=${this._clickUp}></button>
        </div>
        <div id="down">
           <button type="button"
-                  aria-label="Decrement"
+                  tabindex="-1"
                   @click=${this._clickDown}></button>
        </div>
     `;


### PR DESCRIPTION
Close #98

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Accessibility**
  - Updated date picker buttons to be skipped during keyboard tab navigation for improved accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->