### PR TITLE
fix: fix JsonObject cast exception in Vaadin 25

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@
 		<dependency>
 			<groupId>com.flowingcode.vaadin</groupId>
 			<artifactId>json-migration-helper</artifactId>
-			<version>0.9.1</version>
+			<version>0.9.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.projectlombok</groupId>


### PR DESCRIPTION
Close #107 (See https://github.com/FlowingCode/JsonMigrationHelper/issues/29, https://github.com/FlowingCode/JsonMigrationHelper/pull/30)

In json-migration-helper 0.9.2 `convertToClientCallableResult` returns an `ObjectNode` that also implements `JsonObject` instead of `JsonValue`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated json-migration-helper dependency to version 0.9.2.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->